### PR TITLE
feat: add accordion component for hotline numbers

### DIFF
--- a/components/Accordion.vue
+++ b/components/Accordion.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="bg-white p-4 rounded-lg shadow-md">
+    <div
+      class="flex justify-between items-center cursor-pointer"
+      @click="isVisible = !isVisible"
+    >
+      <h2 class="text-gray-600 text-xl font-medium">{{ title }}</h2>
+      <svg
+        v-if="isVisible"
+        width="10"
+        height="10"
+        viewBox="0 0 10 10"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M5 0L10 10H0L5 0Z" fill="#718096" />
+      </svg>
+      <svg
+        v-else
+        width="10"
+        height="11"
+        viewBox="0 0 10 11"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M5 10.3301L1.11265e-06 0.33013L10 0.330131L5 10.3301Z"
+          fill="#718096"
+        />
+      </svg>
+    </div>
+    <div v-if="isVisible" class="border-b-2 border-gray-100 mt-4"></div>
+    <div v-if="isVisible">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    title: {
+      type: String,
+      default: ''
+    },
+    visible: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data() {
+    return {
+      isVisible: this.visible
+    }
+  }
+}
+</script>

--- a/components/LastUpdated.vue
+++ b/components/LastUpdated.vue
@@ -7,7 +7,7 @@
 export default {
   props: {
     lastUpdated: {
-      type: Date,
+      type: String,
       default: ''
     }
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,8 +3,8 @@
     <Notification />
     <div class="max-w-4xl m-auto">
       <Header title="COVID19 Tracker: Zamboanga City"></Header>
-      <LastUpdated lastUpdated="Wed, Mar 25, 2020 9:00 PM"></LastUpdated>
-      <section class="flex justify-between pt-8">
+      <LastUpdated last-updated="Wed, Mar 25, 2020 9:00 PM"></LastUpdated>
+      <section class="flex justify-between mt-8 mb-12">
         <CardCounter
           legend-color="orange"
           card-title="Persons Under Investigation"
@@ -26,6 +26,14 @@
           :increase="1"
         />
       </section>
+
+      <section>
+        <accordion title="Zamboanga Task Force COVID-19" :visible="true">
+          <div class="py-6">
+            <h1 class="font-semibold text-gray-700">Sample Text</h1>
+          </div>
+        </accordion>
+      </section>
     </div>
   </div>
 </template>
@@ -35,13 +43,15 @@ import Notification from '@/components/Notification.vue'
 import CardCounter from '@/components/CardCounter.vue'
 import Header from '@/components/Header.vue'
 import LastUpdated from '@/components/LastUpdated.vue'
+import Accordion from '@/components/Accordion.vue'
 
 export default {
   components: {
     Notification,
     CardCounter,
     Header,
-    LastUpdated
+    LastUpdated,
+    Accordion
   }
 }
 </script>


### PR DESCRIPTION
Re: #3 

- Hyphenate prop name `last-updated`
<img width="612" alt="image" src="https://user-images.githubusercontent.com/17470909/77849273-0010ff80-71fd-11ea-9a60-62c6abd47fc1.png">

- Change `last-updated` prop type to String to avoid errors

Accordion Usage:
```html
<accordion title="Hotline Numbers" :visible="true">
  <h1>Sample Text</h1>
</accordion>
```
**title**: Accordion title
**visible**: Default accordion state

It uses slots for the content.

![covid3](https://user-images.githubusercontent.com/17470909/77849218-9690f100-71fc-11ea-92f8-a71a07c24392.gif)
